### PR TITLE
fix: fixed caddyfile

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,6 +1,11 @@
 # https://caddyserver.com/docs/caddyfile/concepts#environment-variables
 
 :{$CADDY_CONTAINER_PORT} {
-    reverse_proxy /outcomes* http://go-app:8080
-    reverse_proxy http://app:{$APP_CONTAINER_PORT}
+    handle /outcomes* {
+        reverse_proxy go-app:8080
+    }
+
+    handle {
+        reverse_proxy app:{$APP_CONTAINER_PORT}
+    }
 }


### PR DESCRIPTION
This pull request refactors the routing logic in the `caddy/Caddyfile` to use `handle` directives for clearer and more maintainable reverse proxy configuration.

Routing logic improvements:

* Replaced multiple `reverse_proxy` directives with `handle` blocks to separately manage requests to `/outcomes*` (proxied to `go-app:8080`) and all other requests (proxied to `app:{$APP_CONTAINER_PORT}`).<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #<issue-number>

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch-name>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
